### PR TITLE
fix: fix bubble and overlay shapes padding

### DIFF
--- a/lib/src/bubble_shape.dart
+++ b/lib/src/bubble_shape.dart
@@ -31,7 +31,7 @@ class BubbleShape extends ShapeBorder {
   final EdgeInsetsGeometry bubbleDimensions;
 
   @override
-  EdgeInsetsGeometry get dimensions => const EdgeInsets.all(10.0);
+  EdgeInsetsGeometry get dimensions => bubbleDimensions;
 
   @override
   Path getInnerPath(Rect rect, {TextDirection? textDirection}) => Path()

--- a/lib/src/shape_overlay.dart
+++ b/lib/src/shape_overlay.dart
@@ -19,7 +19,7 @@ class ShapeOverlay extends ShapeBorder {
   final EdgeInsetsGeometry overlayDimensions;
 
   @override
-  EdgeInsetsGeometry get dimensions => const EdgeInsets.all(10.0);
+  EdgeInsetsGeometry get dimensions => overlayDimensions;
 
   @override
   Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>


### PR DESCRIPTION
`bubbleDimensions` and `overlayDimensions` are present but not being utilized in the ShapeBorder implementation.

