### PR TITLE
Feature to add curve with custom radius to the arrow tip 

### DIFF
--- a/lib/src/bubble_shape.dart
+++ b/lib/src/bubble_shape.dart
@@ -9,6 +9,7 @@ class BubbleShape extends ShapeBorder {
     required this.preferredDirection,
     required this.target,
     required this.borderRadius,
+    required this.arrowTipRadius,
     required this.arrowBaseWidth,
     required this.arrowTipDistance,
     required this.borderColor,
@@ -24,6 +25,7 @@ class BubbleShape extends ShapeBorder {
   final double arrowBaseWidth;
   final double arrowTipDistance;
   final double borderRadius;
+  final double arrowTipRadius;
   final Color borderColor;
   final double borderWidth;
   final double? left, top, right, bottom;
@@ -93,7 +95,24 @@ class BubbleShape extends ShapeBorder {
             ),
             rect.top,
           )
-          ..lineTo(target.dx, target.dy + arrowTipDistance) // up to arrow tip
+          // up to arrow tip where the curve starts
+          ..lineTo(
+              target.dx + arrowTipRadius / sqrt(2), //sin and cos 45 = 1/root(2)
+              target.dy +
+                  arrowTipDistance -
+                  (arrowTipRadius - arrowTipRadius / sqrt(2)))
+
+          //arc for the tip
+          ..arcToPoint(
+              Offset(
+                  target.dx - arrowTipRadius / sqrt(2),
+                  target.dy +
+                      arrowTipDistance -
+                      (arrowTipRadius - arrowTipRadius / sqrt(2))),
+              radius: Radius.circular(arrowTipRadius),
+              clockwise: false)
+
+          //  down /
           ..lineTo(
             max(
               min(
@@ -103,8 +122,7 @@ class BubbleShape extends ShapeBorder {
               rect.left + topLeftRadius,
             ),
             rect.top,
-          ) //  down /
-
+          )
           ..lineTo(rect.left + topLeftRadius, rect.top)
           ..arcToPoint(
             Offset(rect.left, rect.top + topLeftRadius),
@@ -130,10 +148,23 @@ class BubbleShape extends ShapeBorder {
                   rect.right - bottomRightRadius),
               rect.bottom)
 
-          // up to arrow tip   \
-          ..lineTo(target.dx, target.dy - arrowTipDistance)
+          // down to arrow tip curvature start\
+          ..lineTo(
+              target.dx + arrowTipRadius / sqrt(2), //sin and cos 45 = 1/root(2)
+              target.dy -
+                  arrowTipDistance +
+                  (arrowTipRadius - arrowTipRadius / sqrt(2)))
 
-          //  down /
+          //arc for the tip
+          ..arcToPoint(
+              Offset(
+                  target.dx - arrowTipRadius / sqrt(2),
+                  target.dy -
+                      arrowTipDistance +
+                      (arrowTipRadius - arrowTipRadius / sqrt(2))),
+              radius: Radius.circular(arrowTipRadius))
+
+          //  up /
           ..lineTo(
               max(
                   min(target.dx - arrowBaseWidth / 2,
@@ -155,8 +186,25 @@ class BubbleShape extends ShapeBorder {
                   min(target.dy - arrowBaseWidth / 2,
                       rect.bottom - bottomRightRadius - arrowBaseWidth),
                   rect.top + topRightRadius))
+
+          // right to arrow tip to the start point of the arc \
           ..lineTo(
-              target.dx - arrowTipDistance, target.dy) // right to arrow tip   \
+              target.dx -
+                  arrowTipDistance +
+                  (arrowTipRadius - arrowTipRadius / sqrt(2)),
+              target.dy - arrowTipRadius / sqrt(2))
+
+          //arc for the tip
+          ..arcToPoint(
+            Offset(
+              target.dx -
+                  arrowTipDistance +
+                  (arrowTipRadius - arrowTipRadius / sqrt(2)),
+              target.dy + arrowTipRadius / sqrt(2),
+            ),
+            radius: Radius.circular(arrowTipRadius),
+          )
+
           //  left /
           ..lineTo(
               rect.right,
@@ -181,8 +229,23 @@ class BubbleShape extends ShapeBorder {
                       rect.bottom - bottomLeftRadius - arrowBaseWidth),
                   rect.top + topLeftRadius))
 
-          //left to arrow tip   /
-          ..lineTo(target.dx + arrowTipDistance, target.dy)
+          //left to arrow tip till curve start/
+
+          ..lineTo(
+              target.dx +
+                  arrowTipDistance -
+                  (arrowTipRadius - arrowTipRadius / sqrt(2)),
+              target.dy - arrowTipRadius / sqrt(2))
+
+          //arc for the tip
+          ..arcToPoint(
+              Offset(
+                  target.dx +
+                      arrowTipDistance -
+                      (arrowTipRadius - arrowTipRadius / sqrt(2)),
+                  target.dy + arrowTipRadius / sqrt(2)),
+              radius: Radius.circular(arrowTipRadius),
+              clockwise: false)
 
           //  right \
           ..lineTo(
@@ -288,6 +351,7 @@ class BubbleShape extends ShapeBorder {
       preferredDirection: preferredDirection,
       target: target,
       borderRadius: borderRadius,
+      arrowTipRadius: arrowTipRadius,
       arrowBaseWidth: arrowBaseWidth,
       arrowTipDistance: arrowTipDistance,
       borderColor: borderColor,

--- a/lib/src/super_tooltip.dart
+++ b/lib/src/super_tooltip.dart
@@ -44,6 +44,7 @@ class SuperTooltip extends StatefulWidget {
   final Duration fadeOutDuration;
   final double arrowLength;
   final double arrowBaseWidth;
+  final double arrowTipRadius;
   final double arrowTipDistance;
   final double borderRadius;
   final double borderWidth;
@@ -120,6 +121,7 @@ class SuperTooltip extends StatefulWidget {
     this.fadeOutDuration = const Duration(milliseconds: 0),
     this.arrowLength = 20.0,
     this.arrowBaseWidth = 20.0,
+    this.arrowTipRadius = 0.0,
     this.arrowTipDistance = 2.0,
     this.touchThroughAreaShape = ClipAreaShape.oval,
     this.touchThroughAreaCornerRadius = 5.0,
@@ -426,6 +428,7 @@ class _SuperTooltipState extends State<SuperTooltip>
                                 shape: BubbleShape(
                                   arrowBaseWidth: widget.arrowBaseWidth,
                                   arrowTipDistance: widget.arrowTipDistance,
+                                  arrowTipRadius: widget.arrowTipRadius,
                                   borderColor: widget.borderColor,
                                   borderRadius: widget.borderRadius,
                                   borderWidth: widget.borderWidth,


### PR DESCRIPTION
Currently, the arrow tip have a sharp point (V). This feature is added to give the functionality to give a curve at the tip with a custom radius which can be given explicitly

![Screenshot 2024-09-03 at 4 45 30 PM](https://github.com/user-attachments/assets/28bd9f28-514e-40df-aada-a5bb2ef1c1d4)


In all the directions, right now the arrow is formed by joining two straight lines. In this PR, i have added an arc between two straight lines to form a curve with a custom radius.
As shown in the diagram, i have taken an arc of a small circle with center (0,0), radius R and an angle of 90°. So, the points on the circle between arc is created will be (-R Sin 45°, R Cos 45°) and (R Sin 45°, R Cos 45°). And Cos45° and Sin 45° value is 1/√ 2. 
So the exact point of the start of the curve would be (target.dx - R/√ 2 ,  target.dy + arrow_tip_length - (R - R/√ 2)). As the distance of the start position on y axis will be -> target.dy + arrow_tip_length - (R - R Cos45°) . Hence, i have created a straight line first upto this point , then added a curve to the point  (target.dx + R/√ 2 ,  target.dy + arrow_tip_length - (R - R/√ 2)) with radius R. Then a straight line as before to the point on the rectangle. Similarly, I have added this in all the directions with proper points and angles. 
Default value arrowTipRadius(R) is set to be 0 which will give a sharp tip as before since there will be no arc in that case. Then developer can give custom arrowTipRadius for the curve.