### PR TITLE
fix: hide tooltip doesn't work when tap arrow

### DIFF
--- a/lib/src/super_tooltip.dart
+++ b/lib/src/super_tooltip.dart
@@ -223,13 +223,13 @@ class _SuperTooltipState extends State<SuperTooltip>
       link: _layerLink,
       child: GestureDetector(
         onTap: () {
-            if (widget.toggleOnTap && _superTooltipController!.isVisible) {
-              _superTooltipController!.hideTooltip();
-            } else {
-              if (widget.showOnTap) {
-                _superTooltipController!.showTooltip();
-                }
+          if (widget.toggleOnTap && _superTooltipController!.isVisible) {
+            _superTooltipController!.hideTooltip();
+          } else {
+            if (widget.showOnTap) {
+              _superTooltipController!.showTooltip();
             }
+          }
         },
         onLongPress: widget.onLongPress,
         child: widget.child,
@@ -389,6 +389,7 @@ class _SuperTooltipState extends State<SuperTooltip>
                   Material(
                     color: Colors.transparent,
                     child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
                       onTap: () {
                         if (widget.hideTooltipOnTap)
                           _superTooltipController!.hideTooltip();


### PR DESCRIPTION
Currently, `hideTooltipOnTap` doesn't work when we tap the arrow, so I fixed it by adjusting 'GestureDetector' behaviour to `HitTestBehavior.opaque`